### PR TITLE
Update to terminal_game_engine 0.4.1

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -114,15 +114,15 @@ module Snek
           head = @snek.last
 
           case key
-          when 'q'.ord, TerminalGameEngine::Input::Keys::ESCAPE, TerminalGameEngine::Input::Keys::CTRL_C
+          when 'q', TerminalGameEngine::Input::Keys::ESCAPE, TerminalGameEngine::Input::Keys::CTRL_C
             exit
-          when 'w'.ord
+          when 'w'
             @snek.direction = 'n' if @snek.direction != 's'
-          when 's'.ord
+          when 's'
             @snek.direction = 's' if @snek.direction != 'n'
-          when 'd'.ord
+          when 'd'
             @snek.direction = 'e' if @snek.direction != 'w'
-          when 'a'.ord
+          when 'a'
             @snek.direction = 'w' if @snek.direction != 'e'
           end
         end

--- a/snek.gemspec
+++ b/snek.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'terminal_game_engine', '~> 0.1.2'
+  spec.add_dependency 'terminal_game_engine', '~> 0.4.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 11.0'


### PR DESCRIPTION
`TerminalGameEngine::Input.call` now yields a character rather than a character code